### PR TITLE
Added datacite metadata download feature.

### DIFF
--- a/geonode_mapstore_client/client/js/plugins/downloads/DataCiteDownload.jsx
+++ b/geonode_mapstore_client/client/js/plugins/downloads/DataCiteDownload.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022, GeoSolutions Sas.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+*/
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { createPlugin } from '@mapstore/framework/utils/PluginsUtils';
+import Message from '@mapstore/framework/components/I18N/Message';
+import Button from '@js/components/Button';
+import { downloadMetaData } from '@js/actions/gndownload';
+import { gnDownloadMetaData } from '@js/epics/gndownload';
+import Spinner from '@js/components/Spinner';
+import gnDownload from '@js/reducers/gndownload';
+
+function DataCiteDownload({ onDownload, resourcePk, isDownloading }) {
+    return (
+        <Button variant="default" onClick={() => onDownload('DataCite', resourcePk)}>
+            {isDownloading && <Spinner animation="border" role="status">
+                <span className="sr-only">Loading...</span>
+            </Spinner>} <Message msgId="gnviewer.dataCite" />
+        </Button>
+    );
+}
+
+const DataCiteDownloadPlugin = connect(
+    createSelector([
+        state => state?.gnresource?.data.pk || null,
+        state => state?.gnDownload?.downloads?.DataCite || {}
+    ], (resourcePk, downloadingResources) => ({
+        resourcePk,
+        isDownloading: downloadingResources[resourcePk]
+    })),
+    {
+        onDownload: downloadMetaData
+    }
+)(DataCiteDownload);
+
+DataCiteDownload.defaultProps = {
+    onDownload: () => { },
+    resourcePk: null,
+    isDownloading: false
+};
+
+export default createPlugin('DataCiteDownload', {
+    component: () => null,
+    containers: {
+        ActionNavbar: {
+            name: 'DataCiteDownload',
+            Component: DataCiteDownloadPlugin
+        }
+    },
+    epics: { gnDownloadMetaData },
+    reducers: { gnDownload }
+});

--- a/geonode_mapstore_client/client/js/plugins/index.js
+++ b/geonode_mapstore_client/client/js/plugins/index.js
@@ -408,6 +408,10 @@ export const plugins = {
         'DublinCoreDownload',
         () => import(/* webpackChunkName: 'plugins/iso-download-plugin' */ '@js/plugins/downloads/DublinCoreDownload')
     ),
+    DataCiteDownloadPlugin: toModulePlugin(
+        'DataCiteDownload',
+        () => import('@js/plugins/downloads/DataCiteDownload')
+    ),
     ResourcesGridPlugin: toModulePlugin(
         'ResourcesGrid',
         () => import(/* webpackChunkName: 'plugins/resources-grid' */ '@js/plugins/ResourcesGrid')

--- a/geonode_mapstore_client/client/js/reducers/gndownload.js
+++ b/geonode_mapstore_client/client/js/reducers/gndownload.js
@@ -11,7 +11,8 @@ import { DOWNLOAD_METADATA, DOWNLOAD_METADATA_COMPLETE } from '@js/actions/gndow
 const defaultState = {
     downloads: {
         ISO: {},
-        DublinCore: {}
+        DublinCore: {},
+        DataCite: {}
     }
 };
 

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -616,6 +616,10 @@
                                 {
                                     "type": "plugin",
                                     "name": "DublinCoreDownload"
+                                },
+                                {
+                                    "type": "plugin",
+                                    "name": "DataCiteDownload"
                                 }
                             ]
                         },

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -970,6 +970,9 @@
                 "name": "DublinCoreDownload"
             },
             {
+                "name": "DataCiteDownload"
+            },
+            {
                 "name": "LayerDownload",
                 "cfg": {
                     "disablePluginIf": "{!state('selectedLayerPermissions').includes('download_resourcebase')}",

--- a/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
+++ b/geonode_mapstore_client/static/mapstore/gn-translations/data.en-US.json
@@ -303,6 +303,7 @@
             "directLink": "Direct Link",
             "iso": "ISO Metadata",
             "dublinCore": "Dublin Core Metadata",
+            "dataCite": "DataCite Metadata",
             "owner": "Owner",
             "creation": "Creation",
             "publication": "Publication",


### PR DESCRIPTION
The plugin to download DataCite metadata.

Resolves https://github.com/Thuenen-GeoNode-Development/Sprints/issues/5