### PR TITLE
Fixed the bug where info button for a layer on maps page was crashing the application

### DIFF
--- a/geonode_mapstore_client/client/js/epics/layerdetailviewer.js
+++ b/geonode_mapstore_client/client/js/epics/layerdetailviewer.js
@@ -26,7 +26,11 @@ export const gnGetLayerLinkedResources = (action$, store) =>
         .switchMap((action) =>
             Observable.defer(() =>
                 getLinkedResourcesByPk(action.data.pk)
-                    .then((linkedResources) => linkedResources)
+                    .then((linkedResources) => {
+                        const linkedTo = linkedResources.linked_to ?? [];
+                        const linkedBy = linkedResources.linked_by ?? [];
+                        return isEmpty(linkedTo) && isEmpty(linkedBy) ? {} : ({ linkedTo, linkedBy });
+                    })
                     .catch(() => [])
             ).switchMap((linkedResources) =>
                 Observable.of(

--- a/geonode_mapstore_client/static/mapstore/configs/localConfig.json
+++ b/geonode_mapstore_client/static/mapstore/configs/localConfig.json
@@ -2664,7 +2664,7 @@
                         {
                             "type": "linked-resources",
                             "id": "related",
-                            "labelId": "gnviewer.linkedResources",
+                            "labelId": "gnviewer.linkedResources.label",
                             "items": "{context.get(state('gnLayerResourceData'), 'linkedResources')}"
                         }
                     ]


### PR DESCRIPTION
As discussed elsewhere, the `getResourceByTypeAndByPk` potentially could be replaced by `getResourceByPk`, but doing so will not get the attribute set of the dataset, which won't show the `Attribute` tab on the details panel.